### PR TITLE
Add Steve Burns generic Bitonic Sort generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ Chisel IP Contributions
 If you are here you are hopefully considering contributing some useful chisel modules to
 the community. This is the place to do it.
 
-> More and more users are finding IntelliJ to be a powerful tool for Chisel coding. See the 
-[IntelliJ Installation Guide](https://github.com/ucb-bar/chisel-template/wiki/IntelliJ-Installation-Guide) for how to install it.
+## Contributions
 
-## Add your Chisel code
+| Package | Type | Author | Descpription |
+| --- | --- | --- | --- |
+| BitonicSorter   | internal |  Steve Burns  | A combinational sort generator for arbitrarily typed Vectors |
+
+
 ### Getting Started
 
 To begin with you should have some working Chisel code. 
@@ -17,11 +20,10 @@ placing your circuit and it's unit tests in those respective directories.
 
 ### The Requirements
 
-- Code Style
-- Unit Tests
-- Useful Readme
-- License
-- Other documentation
+- Code Style should reasonably follow the default style guide used by the Chisel3 project. See [the chisel3 scalastyle-config](https://github.com/freechipsproject/chisel3/blob/master/scalastyle-config.xml)
+- Unit Tests should be provided that reasonable confidence that a contribution works
+- Useful README.md should be added in your package directory with contribution specific info.
+- Licensing this code is still a  **WIP**
 
 ### Vetting
 

--- a/src/main/scala/chisel/lib/bitonicsorter/BitonicSorter.scala
+++ b/src/main/scala/chisel/lib/bitonicsorter/BitonicSorter.scala
@@ -1,0 +1,94 @@
+// See README.md for license details.
+
+package chisel.lib.bitonicsorter
+
+import chisel3._
+import chisel3.util._
+
+/**
+  * Builds a mux whose that tests its two inputs
+  * Construct hardware to swap inputs to outputs or pass them straight through depending on comparison function
+  * otherwise
+  * @param proto  The type generator for the swapper
+  * @param lt     The comparision function
+  * @tparam T     The type of the inputs and outputs, derived from proto
+  */
+class Swapper[T <: Data]( proto : T, lt : (T,T) => Bool) extends Module {
+  val io = IO(new Bundle {
+    val a0 = Input( proto )
+    val a1 = Input( proto )
+    val z0 = Output( proto )
+    val z1 = Output( proto )
+  })
+  when ( lt(io.a1,io.a0)) {
+    io.z0 := io.a1
+    io.z1 := io.a0
+  } .otherwise {
+    io.z0 := io.a0
+    io.z1 := io.a1
+  }
+}
+
+/**
+  * Bitonic Sorter is a factory for combinational sort hardware.
+  * It requires that the elements to be sorted are a power of 2.
+  *
+  * @see https://en.wikipedia.org/wiki/Bitonic_sorter
+  *
+  */
+object BitonicSorter {
+  def apply[T <: Data]( a : IndexedSeq[Option[T]], factory : () => Swapper[T]) : IndexedSeq[Option[T]] = {
+    assert( (1 << log2Up(a.length)) == a.length)
+    def insertSorter( a : IndexedSeq[Option[T]], lo : Int, hi : Int) : IndexedSeq[Option[T]] = {
+      (a(lo),a(hi)) match {
+        case (_, None) => a
+        case (None, Some(aH)) => a updated (lo,Some(aH)) updated (hi,None)
+        case (Some(aL), Some(aH)) =>
+          val m = Module( factory())
+          m.io.a0 := aL
+          m.io.a1 := aH
+          a updated (lo,Some(m.io.z0)) updated (hi,Some(m.io.z1))
+      }
+    }
+    (for { i <- 0 until log2Up(a.length)
+           j <- i to 0 by -1
+           k0 <- a.indices by (2<<j)
+           k1 <- 0 until 1<<j} yield {
+      val lo = k0 + k1
+      val hi = lo + (1<<j)
+      if ( (lo >> (i + 1)) % 2 == 0) (lo, hi) else (hi, lo)
+    }).foldLeft(a){ case (s,(l,h)) => insertSorter( s, l, h)}
+  }
+}
+
+/**
+  * Defines the interface used for the Bitonic Sort module
+  * @param n      The number of elements
+  * @param proto  An instance of the type of all elements
+  * @tparam T     The type as derived from proto
+  */
+class SorterModuleIfc[T <: Data](val n : Int, proto : T) extends Module {
+  val io = IO( new Bundle {
+    val a = Input( Vec( n, proto.cloneType))
+    val z = Output( Vec( n, proto.cloneType))
+  })
+}
+
+/*
+  * What follows are some example code generation calls.
+  */
+
+class BitonicSorterModule[T <: Data]( n : Int, proto : T, lt : (T,T) => Bool) extends SorterModuleIfc(n,proto) {
+  private val a = IndexedSeq.tabulate( 1 << log2Up(io.a.length)){ i => if ( i < n) Some(io.a(i)) else None}
+  io.z := VecInit( BitonicSorter( a, () => new Swapper( proto.cloneType, lt)).slice( 0, n) map (_.get))
+}
+
+//scalastyle:off magic.number
+object BitonicSorterUInt8_64Driver extends App {
+  Driver.execute( args, () => new BitonicSorterModule( 64, UInt(8.W), (x:UInt,y:UInt)=>x<y))
+}
+
+//scalastyle:off magic.number
+object BitonicSorterUInt8_384Driver extends App {
+  Driver.execute( args, () => new BitonicSorterModule( 384, UInt(8.W), (x:UInt,y:UInt)=>x<y))
+}

--- a/src/main/scala/chisel/lib/bitonicsorter/README.md
+++ b/src/main/scala/chisel/lib/bitonicsorter/README.md
@@ -1,0 +1,15 @@
+# Bitonic Sorter
+
+## Background
+
+Hardware based sorting is generally nontrivial and exceptionally resource intensive.
+This package provides generic sort combinational support to Vec.
+It does not contains state or memory.
+The size of the generated module grows rapidly with increasing element size and the number of elements.
+With that in mind, use caution.
+There are some use cases where Sort would be nice to have.
+
+## Usage
+The generator creates a module that combinational sorts an input Vec immediately into an output Vec.
+Check out the unit tests for examples of different kinds of elements, comparison functions and sizes.
+

--- a/src/test/scala/chisel/lib/bitonicsorter/ExhaustiveSorterTest.scala
+++ b/src/test/scala/chisel/lib/bitonicsorter/ExhaustiveSorterTest.scala
@@ -1,0 +1,47 @@
+// See README.md for license details.
+
+package chisel.lib.bitonicsorter
+
+import chisel3._
+import chisel3.iotesters._
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * Test generator that tests all possible input patterns
+  * @param factory The generator
+  * @tparam T      The type of elements
+  */
+class ExhaustiveSorterTest[T <: Bool]( factory : () => SorterModuleIfc[T]) extends FlatSpec with Matchers {
+  behavior of "SorterTest"
+
+  it should "work" in {
+    chisel3.iotesters.Driver( factory, "treadle") { c =>
+      new PeekPokeTester( c) {
+        def example( a:IndexedSeq[BigInt]) {
+          poke( c.io.a, a)
+          step(1)
+          expect( c.io.z, a.sortWith( _>_))
+        }
+
+        for { i <- 0 to c.n } {
+          for { on <-(0 until c.n).combinations(i)} {
+            val v = on.foldLeft( IndexedSeq.fill(c.n){ BigInt(0)}){ case (x,y) =>
+              x updated (y,BigInt(1))
+            }
+            example( v)
+          }
+        }
+
+      }
+    } should be (true)
+  }
+}
+
+class ExhaustiveBitonicSorterTest2  extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(2))
+class ExhaustiveBitonicSorterTest3  extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(3))
+class ExhaustiveBitonicSorterTest4  extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(4))
+class ExhaustiveBitonicSorterTest6  extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(6))
+class ExhaustiveBitonicSorterTest8  extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(8))
+class ExhaustiveBitonicSorterTest12 extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(12))
+class ExhaustiveBitonicSorterTest16 extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(16))
+//class ExhaustiveBitonicSorterTest20 extends ExhaustiveSorterTest( () => new BoolBitonicSorterModule(20))

--- a/src/test/scala/chisel/lib/bitonicsorter/RandomSorterTest.scala
+++ b/src/test/scala/chisel/lib/bitonicsorter/RandomSorterTest.scala
@@ -1,0 +1,50 @@
+// See README.md for license details.
+
+package chisel.lib.bitonicsorter
+
+import chisel3._
+import chisel3.iotesters._
+import org.scalatest.{FlatSpec, Matchers}
+
+//scalastyle:off magic.number
+
+/**
+  * Test generator that tests an assortment of random input patterns
+  * @author Steve Burns
+  *
+  * @param numExamples examples to test
+  * @param factory     sorter factory
+  * @tparam T          element type
+  */
+class RandomSorterTest[T <: UInt](
+  val numExamples : Int,
+  factory : () => SorterModuleIfc[T]
+) extends FlatSpec with Matchers {
+
+  behavior of "SorterTest"
+
+  it should "work" in {
+    chisel3.iotesters.Driver( factory, "treadle") { c =>
+      new PeekPokeTester( c) {
+        def example( a:IndexedSeq[BigInt]) {
+          poke( c.io.a, a)
+          step(1)
+          expect( c.io.z, a.sortWith( _>_))
+        }
+
+        for { _ <- 0 until numExamples } {
+          val a = IndexedSeq.fill(c.n)( BigInt( c.io.a(0).getWidth, rnd))
+          example( a)
+        }
+
+      }
+    } should be (true)
+  }
+}
+
+class BoolBitonicSorterModule( n : Int) extends BitonicSorterModule( n, Bool(), (x:UInt,y:UInt)=>x<y)
+class UInt8BitonicSorterModule( n : Int) extends BitonicSorterModule( n, UInt(8.W), (x:UInt,y:UInt)=>x<y)
+
+class RandomBitonicSorterTest64  extends RandomSorterTest( 10000, () => new UInt8BitonicSorterModule( 64))
+//This tests takes a bit long to do every time
+// class RandomBitonicSorterTest384 extends RandomSorterTest( 10000, () => new UInt8BitonicSorterModule( 384))


### PR DESCRIPTION
- Combinationally sorts an input Vec into an output Vec
- Allows specifying element types, comparison function, and Vec size
- Testers include exhaustive and random tests for a number of configurations
- A simple README is included at the package level
- The top level README has been updated to describe this contribution