### PR TITLE
Make project use compiler 2.12 and depend on dsptools

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,9 +30,12 @@ name := "ip-contributions"
 
 version := "1.0.0"
 
-scalaVersion := "2.12.8"
+val scala211 = "2.11.12"
+val scala212 = "2.12.8"
 
-crossScalaVersions := Seq("2.11.12", "2.12.4")
+scalaVersion := scala212
+
+crossScalaVersions := Seq(scala212, scala211)
 
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ name := "ip-contributions"
 
 version := "1.0.0"
 
-scalaVersion := "2.11.12"
+scalaVersion := "2.12.8"
 
 crossScalaVersions := Seq("2.11.12", "2.12.4")
 
@@ -41,11 +41,13 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.1.+",
-  "chisel-iotesters" -> "[1.2.5,1.3-SNAPSHOT["
+  "chisel3" -> "3.2-SNAPSHOT",
+  "chisel-iotesters" -> "1.3-SNAPSHOT",
+  "chisel-testers2" -> "0.1-SNAPSHOT",
+  "dsptools"         -> "1.2-SNAPSHOT"
   )
 
-libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {
+libraryDependencies ++= Seq("chisel3", "chisel-testers2", "chisel-iotesters", "dsptools").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
 
 scalacOptions ++= scalacOptionsVersion(scalaVersion.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.1.1
+sbt.version = 1.2.7


### PR DESCRIPTION
- make scala version 2.12
- cleanup versions of projects this depends on
- add dsptools as a dependency
- update sbt version

This work done to pave the way for bringing Cordic implementations into the project