### PR TITLE
Add ECC generator and checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ the community. This is the place to do it.
 | fifo | internal | Martin Schoeberl | Variations of FIFO queues |
 | spi2wb | maven | Fabien Marteau | Drive a wishbone master bus with SPI |
 | dclib | internal | Guy Hutchison | Utility components for DecoupledIO interfaces |
+| ecc | internal | Guy Hutchison | Hamming Error-Correcting code modules |
 
 ### Getting Started
 
-To begin with you should have some working Chisel code. 
+To begin with you should have some working Chisel code.
 Adding it is designed to be as simple as possible.
 There are two main ways to go about this.
 1. Creating a new package here in the src/main/scala and src/test/scala and place your circuit and it's unit tests in those respective directories. [More about this](more-on-locally-provided-contributions)

--- a/build.sbt
+++ b/build.sbt
@@ -44,13 +44,12 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel3" -> "3.2-SNAPSHOT",
   "chisel-iotesters" -> "1.3-SNAPSHOT",
-  "chisel-testers2" -> "0.1-SNAPSHOT",
+  "chiseltest"       -> "0.2-SNAPSHOT",
   "dsptools"         -> "1.2-SNAPSHOT"
   )
 
-libraryDependencies ++= Seq("chisel3", "chisel-testers2", "chisel-iotesters", "dsptools").map {
+libraryDependencies ++= Seq("chiseltest", "chisel-iotesters", "dsptools").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
 
 scalacOptions ++= scalacOptionsVersion(scalaVersion.value)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.7
+sbt.version = 1.2.8

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.8
+sbt.version = 1.2.7

--- a/src/main/scala/chisel/lib/ecc/EccCheck.scala
+++ b/src/main/scala/chisel/lib/ecc/EccCheck.scala
@@ -12,7 +12,7 @@ class EccCheck[D <: Data](data: D, doubleBit : Boolean = true) extends Module {
     val eccIn = Input(UInt(eccBits.W))
     val dataOut = Output(data.cloneType)
     val errorSyndrome = Output(UInt(eccBits.W))
-    val par = if (doubleBit) Some(Input(Bool())) else None
+    val parIn = if (doubleBit) Some(Input(Bool())) else None
     val doubleBitError = if (doubleBit) Some(Output(Bool())) else None
   })
 
@@ -54,6 +54,6 @@ class EccCheck[D <: Data](data: D, doubleBit : Boolean = true) extends Module {
   if (io.doubleBitError.isDefined) {
     val computedParity = Wire(Bool())
     computedParity := io.dataIn.asUInt().xorR() ^ io.eccIn.xorR()
-    io.doubleBitError.get := (io.errorSyndrome =/= 0.U) && (computedParity === io.par.get)
+    io.doubleBitError.get := (io.errorSyndrome =/= 0.U) && (computedParity === io.parIn.get)
   }
 }

--- a/src/main/scala/chisel/lib/ecc/EccCheck.scala
+++ b/src/main/scala/chisel/lib/ecc/EccCheck.scala
@@ -1,3 +1,4 @@
+// See README.md for license details.
 package chisel.lib.ecc
 
 import chisel3._

--- a/src/main/scala/chisel/lib/ecc/EccCheck.scala
+++ b/src/main/scala/chisel/lib/ecc/EccCheck.scala
@@ -8,6 +8,9 @@ class withEcc[D <: Data](dat: D) extends Bundle {
   val data = dat.cloneType
   val ecc = UInt(calcCodeBits(dat.getWidth).W)
   val par = Bool()
+  override def cloneType: this.type = {
+    new withEcc(dat).asInstanceOf[this.type]
+  }
 }
 
 class EccCheck[D <: Data](data: D, doubleBit : Boolean = true) extends Module {
@@ -68,7 +71,10 @@ class EccCheck[D <: Data](data: D, doubleBit : Boolean = true) extends Module {
 object EccCheck {
   def apply[D <: Data](x : withEcc[D]) : withEcc[D] = {
     val withEccOut = Wire(new withEcc[D](x.data))
-    val eccChecker = Module(new EccCheck(x.cloneType, true))
+    val eccChecker = Module(new EccCheck(x.data.cloneType, true))
+    eccChecker.io.dataIn := x.data
+    eccChecker.io.eccIn := x.ecc
+    eccChecker.io.parIn.get := x.par
     withEccOut.data := eccChecker.io.dataOut
     withEccOut.ecc := eccChecker.io.errorSyndrome
     withEccOut.par := eccChecker.io.doubleBitError.get

--- a/src/main/scala/chisel/lib/ecc/EccCheck.scala
+++ b/src/main/scala/chisel/lib/ecc/EccCheck.scala
@@ -38,7 +38,7 @@ class EccCheck[D <: Data](data: D) extends Module {
     val bitSelect : Seq[UInt] = for (j <- buildSeq(i, outWidth)) yield vecIn(j)
     errorSynVec(i) := bitSelect.reduce(_ ^ _)
   }
-  io.errorSyndrome := Cat(errorSynVec.reverse)
+  io.errorSyndrome := Cat(errorSynVec.reverse) ^ io.eccIn
 
   // correct the bit error
   correctedOut := vecIn

--- a/src/main/scala/chisel/lib/ecc/EccCheck.scala
+++ b/src/main/scala/chisel/lib/ecc/EccCheck.scala
@@ -13,27 +13,28 @@ class EccCheck[D <: Data](data: D) extends Module {
     val errorSyndrome = Output(UInt(eccBits.W))
   })
 
-  val bitValue = Wire(Vec(eccBits, Bool()))
+  //val bitValue = Wire(Vec(eccBits, Bool()))
   val outWidth = io.dataIn.getWidth + eccBits
   //val errorSyndrome = Wire(UInt(log2Ceil(outWidth).W))
-  val errorSynVec = Vec(log2Ceil(outWidth), Bool())
-  val vecIn = Vec(outWidth, Bool())
-  val correctedOut = Vec(outWidth, Bool())
-  val reverseMap = calcBitMapping(outWidth, reversed=true)
-  val forwardMap = calcBitMapping(outWidth, reversed=false)
-  val outDataVec = Vec(data.getWidth, Bool())
+  val errorSynVec = Wire(Vec(log2Ceil(outWidth), Bool()))
+  val vecIn = Wire(Vec(outWidth, Bool()))
+  val correctedOut = Wire(Vec(outWidth, Bool()))
+  val reverseMap = calcBitMapping(data.getWidth, reversed=true)
+  val outDataVec = Wire(Vec(data.getWidth, Bool()))
 
   // assign input bits to their correct location in the combined input/ecc vector
-  for (i <- 0 to io.dataIn.getWidth) {
+  for (i <- 0 until io.dataIn.getWidth) {
+    //println("vecin(%d)".format(reverseMap(i)))
     vecIn(reverseMap(i)) := io.dataIn.asUInt()(i)
   }
   // assign eccBits to their location in the combined vector
-  for (i <- 0 to eccBits) {
-    vecIn(1 << i) := io.eccIn(i)
+  for (i <- 0 until eccBits) {
+    //println("vecin(%d)".format((1 << i) - 1))
+    vecIn((1 << i)-1) := io.eccIn(i)
   }
 
   // compute the error syndrome location
-  for (i <- 0 to eccBits) {
+  for (i <- 0 until eccBits) {
     val bitSelect : Seq[UInt] = for (j <- buildSeq(i, outWidth)) yield vecIn(j)
     errorSynVec(i) := bitSelect.reduce(_ ^ _)
   }
@@ -42,12 +43,12 @@ class EccCheck[D <: Data](data: D) extends Module {
   // correct the bit error
   correctedOut := vecIn
   when (io.errorSyndrome =/= 0.U) {
-    correctedOut(io.errorSyndrome-1.U) := ~correctedOut(io.errorSyndrome-1.U)
+    correctedOut(io.errorSyndrome-1.U) := ~vecIn(io.errorSyndrome-1.U)
   }
 
   // construct corrected output data
-  for (i <- 0 to data.getWidth) {
-    outDataVec(i) := correctedOut(forwardMap(i))
+  for (i <- 0 until data.getWidth) {
+    outDataVec(i) := correctedOut(reverseMap(i))
   }
   io.dataOut := Cat(outDataVec.reverse).asTypeOf(data.cloneType)
 }

--- a/src/main/scala/chisel/lib/ecc/EccGenerate.scala
+++ b/src/main/scala/chisel/lib/ecc/EccGenerate.scala
@@ -1,0 +1,23 @@
+package chisel.lib.ecc
+
+import chisel3._
+import chisel3.util.Cat
+
+class EccGenerate[D <: Data](data: D) extends Module {
+  val eccBits = calcCodeBits(data.getWidth)
+
+  val io = IO(new Bundle {
+    val in = Input(data.cloneType)
+    val out = Output(UInt(eccBits.W))
+  })
+
+  val bitValue = Wire(Vec(eccBits, Bool()))
+  val outWidth = io.in.getWidth + eccBits
+  val bitMapping = calcBitMapping(outWidth, false)
+
+  for (i <- 0 to eccBits) {
+    val bitSelect : Seq[UInt] = for (j <- buildSeq(i, outWidth)) yield io.in.asUInt()(bitMapping(j))
+    bitValue(i) := bitSelect.reduce(_ ^ _)
+  }
+  io.out := Cat(bitValue.reverse)
+}

--- a/src/main/scala/chisel/lib/ecc/EccGenerate.scala
+++ b/src/main/scala/chisel/lib/ecc/EccGenerate.scala
@@ -26,3 +26,15 @@ class EccGenerate[D <: Data](data: D, doubleBit : Boolean = true) extends Module
     io.parOut.get := io.dataIn.asUInt().xorR() ^ io.eccOut.xorR()
   }
 }
+
+// Helper function for functional inference
+object EccGenerate {
+  def apply[D <: Data](x : D) : withEcc[D] = {
+    val withEccOut = Wire(new withEcc[D](x))
+    val eccGenerator = Module(new EccGenerate(x.cloneType, true))
+    withEccOut.data := x
+    withEccOut.ecc := eccGenerator.io.eccOut
+    withEccOut.par := eccGenerator.io.parOut.get
+    withEccOut
+  }
+}

--- a/src/main/scala/chisel/lib/ecc/EccGenerate.scala
+++ b/src/main/scala/chisel/lib/ecc/EccGenerate.scala
@@ -8,21 +8,21 @@ class EccGenerate[D <: Data](data: D, doubleBit : Boolean = true) extends Module
   val eccBits = calcCodeBits(data.getWidth)
 
   val io = IO(new Bundle {
-    val in = Input(data.cloneType)
-    val out = Output(UInt(eccBits.W))
-    val par = if (doubleBit) Some(Output(Bool())) else None
+    val dataIn = Input(data.cloneType)
+    val eccOut = Output(UInt(eccBits.W))
+    val parOut = if (doubleBit) Some(Output(Bool())) else None
   })
 
   val bitValue = Wire(Vec(eccBits, Bool()))
-  val outWidth = io.in.getWidth + eccBits
+  val outWidth = io.dataIn.getWidth + eccBits
   val bitMapping = calcBitMapping(data.getWidth, false)
 
   for (i <- 0 until eccBits) {
-    val bitSelect : Seq[UInt] = for (j <- buildSeq(i, outWidth)) yield io.in.asUInt()(bitMapping(j))
+    val bitSelect : Seq[UInt] = for (j <- buildSeq(i, outWidth)) yield io.dataIn.asUInt()(bitMapping(j))
     bitValue(i) := bitSelect.reduce(_ ^ _)
   }
-  io.out := Cat(bitValue.reverse)
-  if (io.par.nonEmpty) {
-    io.par.get := io.in.asUInt().xorR() ^ io.out.xorR()
+  io.eccOut := Cat(bitValue.reverse)
+  if (io.parOut.nonEmpty) {
+    io.parOut.get := io.dataIn.asUInt().xorR() ^ io.eccOut.xorR()
   }
 }

--- a/src/main/scala/chisel/lib/ecc/EccGenerate.scala
+++ b/src/main/scala/chisel/lib/ecc/EccGenerate.scala
@@ -1,3 +1,4 @@
+// See README.md for license details.
 package chisel.lib.ecc
 
 import chisel3._

--- a/src/main/scala/chisel/lib/ecc/EccGenerate.scala
+++ b/src/main/scala/chisel/lib/ecc/EccGenerate.scala
@@ -13,10 +13,17 @@ class EccGenerate[D <: Data](data: D) extends Module {
 
   val bitValue = Wire(Vec(eccBits, Bool()))
   val outWidth = io.in.getWidth + eccBits
-  val bitMapping = calcBitMapping(outWidth, false)
+  val bitMapping = calcBitMapping(data.getWidth, false)
 
-  for (i <- 0 to eccBits) {
+  //println("eccBits=%d width=%d outWidth=%d".format(eccBits, data.getWidth, outWidth) + bitMapping)
+  for (i <- 0 until eccBits) {
+    /*
+    for (j <- buildSeq(i, outWidth)) {
+      println(i, j, bitMapping(j))
+    }
+     */
     val bitSelect : Seq[UInt] = for (j <- buildSeq(i, outWidth)) yield io.in.asUInt()(bitMapping(j))
+    //println("bitSelectList(i=%d):".format(i) + bitSelect)
     bitValue(i) := bitSelect.reduce(_ ^ _)
   }
   io.out := Cat(bitValue.reverse)

--- a/src/main/scala/chisel/lib/ecc/EccGenerate.scala
+++ b/src/main/scala/chisel/lib/ecc/EccGenerate.scala
@@ -4,28 +4,25 @@ package chisel.lib.ecc
 import chisel3._
 import chisel3.util.Cat
 
-class EccGenerate[D <: Data](data: D) extends Module {
+class EccGenerate[D <: Data](data: D, doubleBit : Boolean = true) extends Module {
   val eccBits = calcCodeBits(data.getWidth)
 
   val io = IO(new Bundle {
     val in = Input(data.cloneType)
     val out = Output(UInt(eccBits.W))
+    val par = if (doubleBit) Some(Output(Bool())) else None
   })
 
   val bitValue = Wire(Vec(eccBits, Bool()))
   val outWidth = io.in.getWidth + eccBits
   val bitMapping = calcBitMapping(data.getWidth, false)
 
-  //println("eccBits=%d width=%d outWidth=%d".format(eccBits, data.getWidth, outWidth) + bitMapping)
   for (i <- 0 until eccBits) {
-    /*
-    for (j <- buildSeq(i, outWidth)) {
-      println(i, j, bitMapping(j))
-    }
-     */
     val bitSelect : Seq[UInt] = for (j <- buildSeq(i, outWidth)) yield io.in.asUInt()(bitMapping(j))
-    //println("bitSelectList(i=%d):".format(i) + bitSelect)
     bitValue(i) := bitSelect.reduce(_ ^ _)
   }
   io.out := Cat(bitValue.reverse)
+  if (io.par.nonEmpty) {
+    io.par.get := io.in.asUInt().xorR() ^ io.out.xorR()
+  }
 }

--- a/src/main/scala/chisel/lib/ecc/EccGenerate.scala
+++ b/src/main/scala/chisel/lib/ecc/EccGenerate.scala
@@ -32,6 +32,7 @@ object EccGenerate {
   def apply[D <: Data](x : D) : withEcc[D] = {
     val withEccOut = Wire(new withEcc[D](x))
     val eccGenerator = Module(new EccGenerate(x.cloneType, true))
+    eccGenerator.io.dataIn := x
     withEccOut.data := x
     withEccOut.ecc := eccGenerator.io.eccOut
     withEccOut.par := eccGenerator.io.parOut.get

--- a/src/main/scala/chisel/lib/ecc/README.md
+++ b/src/main/scala/chisel/lib/ecc/README.md
@@ -1,0 +1,40 @@
+Hamming Error-Correcting Code (ECC)
+===================================
+
+This package contains some primitives which are used to generate two modules,
+EccGenerate and EccCorrect.  These implement the generation and detection/
+correction sides of a Hamming error correcting code.  This code is a
+single-bit-correcting code.  With the optional parity bit it can also detect
+but not correct double bit errors.
+
+See https://en.wikipedia.org/wiki/Hamming_code for more information about
+Hamming codes.
+
+## Components
+
+- EccGenerate
+
+The EccGenerate module takes two parameters, a type parameter which indicates 
+Chisel data type to generate an ECC on, and doubleBit, which when true 
+generates an additional parity bit used for double-bit error detection.
+
+In addition to the optional parity output, the EccGenerate has an "eccOut"
+output which contains the error check bits for the input data.
+
+- EccCheck
+
+The EccCheck module takes the same two parameters as EccGenerate above.
+
+As inputs, EccCheck takes the original dataIn, as well as the parity bits
+in eccIn and the optional parity bit in parIn.  From dataIn and eccIn
+the check block computes an "error syndrome", which is the bit location
+(starting from 1) of the incorrect bit among the received data.  An
+error syndrome of zero indicates no error.
+
+The eccCheck block also creates a corrected dataOut signal, which contains
+the original dataIn after any single-bit errors have been removed.  If
+there is more than one bit error dataOut will not be correct.
+
+If only checking is desired without error correction, leave the dataOut
+signal unconnected and use the original uncorrected dataIn bits.  The
+error correction logic will be removed during FIRRTL optimization.

--- a/src/main/scala/chisel/lib/ecc/package.scala
+++ b/src/main/scala/chisel/lib/ecc/package.scala
@@ -1,0 +1,71 @@
+package chisel.lib
+
+import scala.collection.immutable.Map
+import scala.collection.mutable.ListBuffer
+
+package object ecc {
+  def pow2(x : Int) : Int = {
+    scala.math.ceil(scala.math.pow(2, x)).toInt
+  }
+
+  def calcCodeBits(dataBits : Int) : Int = {
+    var m = 1
+    var c = 0
+    while (c < dataBits) {
+      m += 1
+      c = pow2(m) - m - 1
+    }
+    m
+  }
+
+  def calcBitMapping(dataBits: Int, reversed : Boolean) : Map[Int, Int] = {
+    val outWidth = dataBits + calcCodeBits(dataBits)
+    var power : Int = 0
+    var mapping1 = new ListBuffer[Int]()
+    var mapping2 = new ListBuffer[Int]()
+
+    for (i <- 1 until outWidth) {
+      if (pow2(power) == i)
+        power += 1
+      else {
+        mapping1 += (i-1)
+        mapping2 += (i-power-1)
+      }
+    }
+
+    if (reversed)
+      (mapping2 zip mapping1).toMap
+    else
+      (mapping1 zip mapping2).toMap
+  }
+
+  def buildSeq(bitNum : Int, outWidth: Int) : List[Int] = {
+    var bitIndex = new ListBuffer[Int]()
+    var cur = 0
+    var skip = pow2(bitNum)-1
+    var check = 0
+
+    if (skip == 0)
+      check = pow2(bitNum)
+    else
+      check = 0
+
+    while (cur < outWidth) {
+      println(cur, skip, check, bitIndex)
+      if (check > 0) {
+        if (cur != pow2(bitNum)-1)
+          bitIndex += cur
+        check -= 1
+        if (check == 0)
+          skip = pow2(bitNum)
+      } else {
+        skip -= 1
+        if (skip == 0)
+          check = pow2(bitNum)
+      }
+      cur += 1
+    }
+
+    bitIndex.toList
+  }
+}

--- a/src/main/scala/chisel/lib/ecc/package.scala
+++ b/src/main/scala/chisel/lib/ecc/package.scala
@@ -5,7 +5,12 @@ import scala.collection.mutable.ListBuffer
 
 package object ecc {
   def pow2(x : Int) : Int = {
-    scala.math.ceil(scala.math.pow(2, x)).toInt
+    if (x == 0) {
+      1
+    } else {
+      1 << x
+    }
+    //scala.math.ceil(scala.math.pow(2, x)).toInt
   }
 
   def calcCodeBits(dataBits : Int) : Int = {

--- a/src/main/scala/chisel/lib/ecc/package.scala
+++ b/src/main/scala/chisel/lib/ecc/package.scala
@@ -24,7 +24,7 @@ package object ecc {
     var mapping1 = new ListBuffer[Int]()
     var mapping2 = new ListBuffer[Int]()
 
-    for (i <- 1 until outWidth) {
+    for (i <- 1 until outWidth+1) {
       if (pow2(power) == i)
         power += 1
       else {
@@ -51,7 +51,6 @@ package object ecc {
       check = 0
 
     while (cur < outWidth) {
-      println(cur, skip, check, bitIndex)
       if (check > 0) {
         if (cur != pow2(bitNum)-1)
           bitIndex += cur

--- a/src/main/scala/chisel/lib/ecc/package.scala
+++ b/src/main/scala/chisel/lib/ecc/package.scala
@@ -1,3 +1,4 @@
+// See README.md for license details.
 package chisel.lib
 
 import scala.collection.immutable.Map

--- a/src/test/scala/chisel/lib/ecc/EccPair.scala
+++ b/src/test/scala/chisel/lib/ecc/EccPair.scala
@@ -1,0 +1,34 @@
+package chisel.lib.ecc
+import chisel3._
+import chisel3.util._
+
+class EccPair(width : Int) extends Module {
+  val eccBits = calcCodeBits(width)
+  val outWidth = width + eccBits
+
+  val io = IO(new Bundle {
+    val dataIn = Input(UInt(width.W))
+    val dataOut = Output(UInt(width.W))
+    val injectError = Input(Bool())
+    val errorLocation = Input(UInt(log2Ceil(width).W))
+    val syndromeOut = Output(UInt(eccBits.W))
+  })
+
+  def getWidthParam : Int = { width }
+
+  val intermediate = Wire(UInt(width.W))
+  val eccGen = Module(new EccGenerate(io.dataIn.cloneType))
+  val eccCheck = Module(new EccCheck(io.dataIn.cloneType))
+
+  eccGen.io.in := io.dataIn
+
+  when (io.injectError) {
+    intermediate := io.dataIn ^ (1.U << io.errorLocation)
+  }.otherwise {
+    intermediate := io.dataIn
+  }
+
+  eccCheck.io.dataIn := intermediate
+  eccCheck.io.eccIn := eccGen.io.out
+  io.dataOut := eccCheck.io.dataOut
+}

--- a/src/test/scala/chisel/lib/ecc/EccPair.scala
+++ b/src/test/scala/chisel/lib/ecc/EccPair.scala
@@ -16,6 +16,8 @@ class EccPair(width : Int) extends Module {
     val syndromeOut = Output(UInt(eccBits.W))
     val injectSecondError = Input(Bool())
     val secondErrorLocation = Input(UInt(log2Ceil(width).W))
+    val injectEccError = Input(Bool())
+    val eccErrorLocation = Input(UInt(calcCodeBits(width).W))
     val outputNotEqual = Output(Bool())
     val doubleBitError = Output(Bool())
   })

--- a/src/test/scala/chisel/lib/ecc/EccPair.scala
+++ b/src/test/scala/chisel/lib/ecc/EccPair.scala
@@ -1,3 +1,5 @@
+// See README.md for license details.
+
 package chisel.lib.ecc
 import chisel3._
 import chisel3.util._
@@ -15,6 +17,7 @@ class EccPair(width : Int) extends Module {
     val injectSecondError = Input(Bool())
     val secondErrorLocation = Input(UInt(log2Ceil(width).W))
     val outputNotEqual = Output(Bool())
+    val doubleBitError = Output(Bool())
   })
 
   def getWidthParam : Int = { width }
@@ -37,7 +40,9 @@ class EccPair(width : Int) extends Module {
 
   eccCheck.io.dataIn := intermediate
   eccCheck.io.eccIn := eccGen.io.out
+  eccCheck.io.par.get := eccGen.io.par.get
   io.dataOut := eccCheck.io.dataOut
   io.syndromeOut := eccCheck.io.errorSyndrome
   io.outputNotEqual := io.dataIn =/= io.dataOut
+  io.doubleBitError := eccCheck.io.doubleBitError.get
 }

--- a/src/test/scala/chisel/lib/ecc/EccPair.scala
+++ b/src/test/scala/chisel/lib/ecc/EccPair.scala
@@ -31,4 +31,5 @@ class EccPair(width : Int) extends Module {
   eccCheck.io.dataIn := intermediate
   eccCheck.io.eccIn := eccGen.io.out
   io.dataOut := eccCheck.io.dataOut
+  io.syndromeOut := eccCheck.io.errorSyndrome
 }

--- a/src/test/scala/chisel/lib/ecc/EccPair.scala
+++ b/src/test/scala/chisel/lib/ecc/EccPair.scala
@@ -12,6 +12,9 @@ class EccPair(width : Int) extends Module {
     val injectError = Input(Bool())
     val errorLocation = Input(UInt(log2Ceil(width).W))
     val syndromeOut = Output(UInt(eccBits.W))
+    val injectSecondError = Input(Bool())
+    val secondErrorLocation = Input(UInt(log2Ceil(width).W))
+    val outputNotEqual = Output(Bool())
   })
 
   def getWidthParam : Int = { width }
@@ -23,7 +26,11 @@ class EccPair(width : Int) extends Module {
   eccGen.io.in := io.dataIn
 
   when (io.injectError) {
-    intermediate := io.dataIn ^ (1.U << io.errorLocation)
+    when (io.injectSecondError) {
+     intermediate := io.dataIn ^  (1.U << io.errorLocation) ^ (1.U << io.secondErrorLocation)
+    }.otherwise {
+      intermediate := io.dataIn ^ (1.U << io.errorLocation)
+    }
   }.otherwise {
     intermediate := io.dataIn
   }
@@ -32,4 +39,5 @@ class EccPair(width : Int) extends Module {
   eccCheck.io.eccIn := eccGen.io.out
   io.dataOut := eccCheck.io.dataOut
   io.syndromeOut := eccCheck.io.errorSyndrome
+  io.outputNotEqual := io.dataIn =/= io.dataOut
 }

--- a/src/test/scala/chisel/lib/ecc/EccPair.scala
+++ b/src/test/scala/chisel/lib/ecc/EccPair.scala
@@ -26,7 +26,7 @@ class EccPair(width : Int) extends Module {
   val eccGen = Module(new EccGenerate(io.dataIn.cloneType))
   val eccCheck = Module(new EccCheck(io.dataIn.cloneType))
 
-  eccGen.io.in := io.dataIn
+  eccGen.io.dataIn := io.dataIn
 
   when (io.injectError) {
     when (io.injectSecondError) {
@@ -39,8 +39,8 @@ class EccPair(width : Int) extends Module {
   }
 
   eccCheck.io.dataIn := intermediate
-  eccCheck.io.eccIn := eccGen.io.out
-  eccCheck.io.par.get := eccGen.io.par.get
+  eccCheck.io.eccIn := eccGen.io.eccOut
+  eccCheck.io.parIn.get := eccGen.io.parOut.get
   io.dataOut := eccCheck.io.dataOut
   io.syndromeOut := eccCheck.io.errorSyndrome
   io.outputNotEqual := io.dataIn =/= io.dataOut

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -4,7 +4,6 @@ import chisel3._
 import chisel3.iotesters.PeekPokeTester
 
 class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
-
   val dutWidth = dut.getWidthParam
 
   // send through some data without errors
@@ -15,10 +14,23 @@ class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
     step(1)
     expect(dut.io.dataOut, i.U)
   }
+
+  // inject single bit errors
+  for (i <- 0 to dutWidth) {
+    poke(dut.io.errorLocation, i.U)
+    poke(dut.io.injectError, 1.U)
+    poke(dut.io.dataIn, "xFF".U)
+    step(1)
+    expect(dut.io.dataOut, "xFF".U)
+  }
 }
 
 object EccTester extends App {
   iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(8)) {
     dut => new EccTester(dut)
   }
+}
+
+object EccGenerator extends App {
+  chisel3.Driver.execute(Array("--target-dir", "generated"), () => new EccCheck(UInt(8.W)))
 }

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -78,6 +78,27 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
       }
     }
   }
+
+  it should "support functional inference" in {
+    test(new Module {
+      val io = IO(new Bundle {
+        val dataIn = Input(UInt(16.W))
+        val dataOut = Output(UInt(16.W))
+        val doubleBitError = Output(Bool())
+      })
+      val eccOutput = EccCheck(EccGenerate(io.dataIn))
+      io.dataOut := eccOutput.data
+      io.doubleBitError := eccOutput.par
+    }) {
+      c =>
+        for (i <- 0 to 32) {
+          c.io.dataIn.poke(i.U)
+          c.clock.step(1)
+          c.io.dataOut.expect(i.U)
+          c.io.doubleBitError.expect(false.B)
+        }
+    }
+  }
 }
 
 object EccGenerator extends App {

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -3,6 +3,7 @@
 package chisel.lib.ecc
 
 import chisel3._
+import chisel3.util.Fill
 import chiseltest._
 import org.scalatest._
 import chiseltest.experimental.TestOptionBuilder._
@@ -47,8 +48,60 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
             c.io.errorLocation.poke(i.U)
             c.io.injectError.poke(true.B)
             c.io.injectSecondError.poke(false.B)
+            c.io.injectEccError.poke(false.B)
             c.clock.step(1)
             c.io.dataOut.expect(testVal.U)
+            c.io.outputNotEqual.expect(false.B)
+            c.io.doubleBitError.expect(false.B)
+          }
+        }
+      }
+    }
+  }
+
+  it should "correct single-bit ecc errors" in {
+    for (width <- 4 to 30) {
+      test(new EccPair(width = width)) {
+        c => {
+          val rnd = new Random()
+          for (i <- 0 to calcCodeBits(width)) {
+            val testVal = rnd.nextInt(1 << c.getWidthParam)
+
+            c.io.dataIn.poke(testVal.U)
+            c.io.eccErrorLocation.poke(i.U)
+            c.io.injectError.poke(false.B)
+            c.io.injectSecondError.poke(false.B)
+            c.io.injectEccError.poke(true.B)
+            c.clock.step(1)
+            c.io.dataOut.expect(testVal.U)
+            c.io.outputNotEqual.expect(false.B)
+            c.io.doubleBitError.expect(false.B)
+          }
+        }
+      }
+    }
+  }
+
+  it should "support wide values" in {
+    for (width <- Seq(48, 64, 96, 128, 256)) {
+      test(new EccPair(width = width)) {
+        c => {
+          val rnd = new Random()
+          for (i <- 0 to c.getWidthParam) {
+            val testVal = rnd.nextInt(256)
+
+            c.io.dataIn.poke(testVal.U)
+            c.io.errorLocation.poke(i.U)
+            c.io.injectError.poke(true.B)
+            c.clock.step(1)
+            c.io.outputNotEqual.expect(false.B)
+            c.io.doubleBitError.expect(false.B)
+          }
+          for (i <- 0 to calcCodeBits(width)) {
+            c.io.injectError.poke(false.B)
+            c.io.injectEccError.poke(true.B)
+            c.io.eccErrorLocation.poke(i.U)
+            c.clock.step(1)
             c.io.outputNotEqual.expect(false.B)
             c.io.doubleBitError.expect(false.B)
           }
@@ -69,6 +122,7 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
             c.io.errorLocation.poke((i % c.getWidthParam).U)
             c.io.injectError.poke(true.B)
             c.io.injectSecondError.poke(true.B)
+            c.io.injectEccError.poke(false.B)
             c.io.secondErrorLocation.poke(((i + 1) % c.getWidthParam).U)
             c.clock.step(1)
             c.io.outputNotEqual.expect(true.B)

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -5,29 +5,35 @@ import chisel3.iotesters.PeekPokeTester
 
 class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
   val dutWidth = dut.getWidthParam
-
+  var testVal : Int = 0
   // send through some data without errors
   for (i <- 0 to 20) {
-    poke(dut.io.dataIn, i.U)
+    testVal = rnd.nextInt() & ((1 << dutWidth) - 1)
+
+    poke(dut.io.dataIn, testVal.U)
     poke(dut.io.errorLocation, 0.U)
     poke(dut.io.injectError, 0.U)
     step(1)
-    expect(dut.io.dataOut, i.U)
+    expect(dut.io.dataOut, testVal.U)
   }
 
   // inject single bit errors
   for (i <- 0 to dutWidth) {
+    testVal = rnd.nextInt() & ((1 << dutWidth) - 1)
+
     poke(dut.io.errorLocation, i.U)
     poke(dut.io.injectError, 1.U)
-    poke(dut.io.dataIn, "xFF".U)
+    poke(dut.io.dataIn, testVal.U)
     step(1)
-    expect(dut.io.dataOut, "xFF".U)
+    expect(dut.io.dataOut, testVal.U)
   }
 }
 
 object EccTester extends App {
-  iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(8)) {
-    dut => new EccTester(dut)
+  for (width <- 8 to 32) {
+    iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(width=width)) {
+      dut => new EccTester(dut)
+    }
   }
 }
 

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -22,8 +22,10 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
           c.io.dataIn.poke(testVal.U)
           c.io.errorLocation.poke(0.U)
           c.io.injectError.poke(false.B)
+          c.io.injectSecondError.poke(false.B)
           c.clock.step(1)
           c.io.dataOut.expect(testVal.U)
+          c.io.outputNotEqual.expect(false.B)
         }
       }
     }
@@ -39,8 +41,29 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
           c.io.dataIn.poke(testVal.U)
           c.io.errorLocation.poke(i.U)
           c.io.injectError.poke(true.B)
+          c.io.injectSecondError.poke(false.B)
           c.clock.step(1)
           c.io.dataOut.expect(testVal.U)
+          c.io.outputNotEqual.expect(false.B)
+        }
+      }
+    }
+  }
+
+  it should "correct double bit errors" in {
+    test(new EccPair(width=8)) {
+      c => {
+        val rnd = new Random()
+        for (i <- 0 to c.getWidthParam) {
+          val testVal = rnd.nextInt(1 << c.getWidthParam)
+
+          c.io.dataIn.poke(testVal.U)
+          c.io.errorLocation.poke(i.U)
+          c.io.injectError.poke(true.B)
+          c.io.injectSecondError.poke(true.B)
+          c.io.errorLocation.poke(((i+1)%c.getWidthParam).U)
+          c.clock.step(1)
+          c.io.outputNotEqual.expect(true.B)
         }
       }
     }

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -1,8 +1,52 @@
-package chisel.lib.ecc
+//package chisel.lib.ecc
+package chiseltest.tests
 
 import chisel3._
-import chisel3.iotesters.PeekPokeTester
+import chisel3.tester.ChiselScalatestTester
+import org.scalatest._
+//import chisel3.iotesters.PeekPokeTester
+import chiseltest._
+import chisel.lib.ecc._
+import scala.util.Random
 
+class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2"
+
+  it should "send data without errors" in {
+    test(new EccPair(width=8)) {
+      c => {
+        val rnd = new Random()
+        for (i <- 0 to 20) {
+          val testVal = rnd.between(0, 1 << c.getWidthParam)
+
+          c.io.dataIn.poke(testVal.U)
+          c.io.errorLocation.poke(0.U)
+          c.io.injectError.poke(0.U)
+          c.clock.step(1)
+          c.io.dataOut.expect(testVal.U)
+        }
+      }
+    }
+  }
+
+  it should "correct single bit errors" in {
+    test(new EccPair(width=8)) {
+      c => {
+        val rnd = new Random()
+        for (i <- 0 to c.getWidthParam) {
+          val testVal = rnd.between(0, 1 << c.getWidthParam)
+
+          c.io.dataIn.poke(testVal.U)
+          c.io.errorLocation.poke(i.U)
+          c.io.injectError.poke(1.U)
+          c.clock.step(1)
+          c.io.dataOut.expect(testVal.U)
+        }
+      }
+    }
+  }
+}
+/*
 class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
   val dutWidth = dut.getWidthParam
   var testVal : Int = 0
@@ -28,6 +72,7 @@ class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
     expect(dut.io.dataOut, testVal.U)
   }
 }
+*/
 
 object EccTester extends App {
   for (width <- 8 to 32) {

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -1,0 +1,23 @@
+package chisel.lib.ecc
+
+import chisel3.iotesters.PeekPokeTester
+
+class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
+
+  val dutWidth = dut.getWidthParam
+
+  // send through some data without errors
+  for (i <- 0 to 20) {
+    poke(dut.io.dataIn, i)
+    poke(dut.io.errorLocation, 0)
+    poke(dut.io.injectError, 0)
+    step(1)
+    expect(dut.io.dataOut == dut.io.dataIn)
+  }
+}
+
+object EccTester extends App {
+  iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(8)) {
+    c => new EccTester(c)
+  }
+}

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -1,12 +1,12 @@
-//package chisel.lib.ecc
-package chiseltest.tests
+// See README.md for license details.
+
+package chisel.lib.ecc
 
 import chisel3._
-import chisel3.tester.ChiselScalatestTester
+import chiseltest._
 import org.scalatest._
 //import chisel3.iotesters.PeekPokeTester
-import chiseltest._
-import chisel.lib.ecc._
+
 import scala.util.Random
 
 class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
@@ -17,11 +17,11 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
       c => {
         val rnd = new Random()
         for (i <- 0 to 20) {
-          val testVal = rnd.between(0, 1 << c.getWidthParam)
+          val testVal = rnd.nextInt(1 << c.getWidthParam)
 
           c.io.dataIn.poke(testVal.U)
           c.io.errorLocation.poke(0.U)
-          c.io.injectError.poke(0.U)
+          c.io.injectError.poke(false.B)
           c.clock.step(1)
           c.io.dataOut.expect(testVal.U)
         }
@@ -34,11 +34,11 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
       c => {
         val rnd = new Random()
         for (i <- 0 to c.getWidthParam) {
-          val testVal = rnd.between(0, 1 << c.getWidthParam)
+          val testVal = rnd.nextInt(1 << c.getWidthParam)
 
           c.io.dataIn.poke(testVal.U)
           c.io.errorLocation.poke(i.U)
-          c.io.injectError.poke(1.U)
+          c.io.injectError.poke(true.B)
           c.clock.step(1)
           c.io.dataOut.expect(testVal.U)
         }
@@ -75,11 +75,11 @@ class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
 */
 
 object EccTester extends App {
-  for (width <- 8 to 32) {
-    iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(width=width)) {
-      dut => new EccTester(dut)
-    }
-  }
+//  for (width <- 8 to 32) {
+//    iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(width=width)) {
+//      dut => new EccTester(dut)
+//    }
+//  }
 }
 
 object EccGenerator extends App {

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -5,7 +5,8 @@ package chisel.lib.ecc
 import chisel3._
 import chiseltest._
 import org.scalatest._
-//import chisel3.iotesters.PeekPokeTester
+import chiseltest.experimental.TestOptionBuilder._
+import chiseltest.internal.WriteVcdAnnotation
 
 import scala.util.Random
 
@@ -13,96 +14,70 @@ class EccTester extends FlatSpec with ChiselScalatestTester with Matchers {
   behavior of "Testers2"
 
   it should "send data without errors" in {
-    test(new EccPair(width=8)) {
-      c => {
-        val rnd = new Random()
-        for (i <- 0 to 20) {
-          val testVal = rnd.nextInt(1 << c.getWidthParam)
+    for (width <- 4 to 30) {
+      test(new EccPair(width = width)) {
+        c => {
+          val rnd = new Random()
+          for (i <- 0 to 20) {
+            val testVal = rnd.nextInt(1 << c.getWidthParam)
 
-          c.io.dataIn.poke(testVal.U)
-          c.io.errorLocation.poke(0.U)
-          c.io.injectError.poke(false.B)
-          c.io.injectSecondError.poke(false.B)
-          c.clock.step(1)
-          c.io.dataOut.expect(testVal.U)
-          c.io.outputNotEqual.expect(false.B)
+            c.io.dataIn.poke(testVal.U)
+            c.io.errorLocation.poke(0.U)
+            c.io.injectError.poke(false.B)
+            c.io.injectSecondError.poke(false.B)
+            c.clock.step(1)
+            c.io.dataOut.expect(testVal.U)
+            c.io.outputNotEqual.expect(false.B)
+            c.io.doubleBitError.expect(false.B)
+          }
         }
       }
     }
   }
 
   it should "correct single bit errors" in {
-    test(new EccPair(width=8)) {
-      c => {
-        val rnd = new Random()
-        for (i <- 0 to c.getWidthParam) {
-          val testVal = rnd.nextInt(1 << c.getWidthParam)
+    for (width <- 4 to 30) {
+      test(new EccPair(width = width)) {
+        c => {
+          val rnd = new Random()
+          for (i <- 0 to c.getWidthParam) {
+            val testVal = rnd.nextInt(1 << c.getWidthParam)
 
-          c.io.dataIn.poke(testVal.U)
-          c.io.errorLocation.poke(i.U)
-          c.io.injectError.poke(true.B)
-          c.io.injectSecondError.poke(false.B)
-          c.clock.step(1)
-          c.io.dataOut.expect(testVal.U)
-          c.io.outputNotEqual.expect(false.B)
+            c.io.dataIn.poke(testVal.U)
+            c.io.errorLocation.poke(i.U)
+            c.io.injectError.poke(true.B)
+            c.io.injectSecondError.poke(false.B)
+            c.clock.step(1)
+            c.io.dataOut.expect(testVal.U)
+            c.io.outputNotEqual.expect(false.B)
+            c.io.doubleBitError.expect(false.B)
+          }
         }
       }
     }
   }
 
-  it should "correct double bit errors" in {
-    test(new EccPair(width=8)) {
-      c => {
-        val rnd = new Random()
-        for (i <- 0 to c.getWidthParam) {
-          val testVal = rnd.nextInt(1 << c.getWidthParam)
+  it should "detect double bit errors" in {
+    for (width <- 4 to 30) {
+      test(new EccPair(width = width)).withAnnotations(Seq(WriteVcdAnnotation)) {
+        c => {
+          val rnd = new Random()
+          for (i <- 0 to c.getWidthParam) {
+            val testVal = rnd.nextInt(1 << c.getWidthParam)
 
-          c.io.dataIn.poke(testVal.U)
-          c.io.errorLocation.poke(i.U)
-          c.io.injectError.poke(true.B)
-          c.io.injectSecondError.poke(true.B)
-          c.io.errorLocation.poke(((i+1)%c.getWidthParam).U)
-          c.clock.step(1)
-          c.io.outputNotEqual.expect(true.B)
+            c.io.dataIn.poke(testVal.U)
+            c.io.errorLocation.poke((i % c.getWidthParam).U)
+            c.io.injectError.poke(true.B)
+            c.io.injectSecondError.poke(true.B)
+            c.io.secondErrorLocation.poke(((i + 1) % c.getWidthParam).U)
+            c.clock.step(1)
+            c.io.outputNotEqual.expect(true.B)
+            c.io.doubleBitError.expect(true.B)
+          }
         }
       }
     }
   }
-}
-/*
-class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
-  val dutWidth = dut.getWidthParam
-  var testVal : Int = 0
-  // send through some data without errors
-  for (i <- 0 to 20) {
-    testVal = rnd.nextInt() & ((1 << dutWidth) - 1)
-
-    poke(dut.io.dataIn, testVal.U)
-    poke(dut.io.errorLocation, 0.U)
-    poke(dut.io.injectError, 0.U)
-    step(1)
-    expect(dut.io.dataOut, testVal.U)
-  }
-
-  // inject single bit errors
-  for (i <- 0 to dutWidth) {
-    testVal = rnd.nextInt() & ((1 << dutWidth) - 1)
-
-    poke(dut.io.errorLocation, i.U)
-    poke(dut.io.injectError, 1.U)
-    poke(dut.io.dataIn, testVal.U)
-    step(1)
-    expect(dut.io.dataOut, testVal.U)
-  }
-}
-*/
-
-object EccTester extends App {
-//  for (width <- 8 to 32) {
-//    iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(width=width)) {
-//      dut => new EccTester(dut)
-//    }
-//  }
 }
 
 object EccGenerator extends App {

--- a/src/test/scala/chisel/lib/ecc/EccTester.scala
+++ b/src/test/scala/chisel/lib/ecc/EccTester.scala
@@ -1,5 +1,6 @@
 package chisel.lib.ecc
 
+import chisel3._
 import chisel3.iotesters.PeekPokeTester
 
 class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
@@ -8,16 +9,16 @@ class EccTester(dut: EccPair) extends PeekPokeTester(dut) {
 
   // send through some data without errors
   for (i <- 0 to 20) {
-    poke(dut.io.dataIn, i)
-    poke(dut.io.errorLocation, 0)
-    poke(dut.io.injectError, 0)
+    poke(dut.io.dataIn, i.U)
+    poke(dut.io.errorLocation, 0.U)
+    poke(dut.io.injectError, 0.U)
     step(1)
-    expect(dut.io.dataOut == dut.io.dataIn)
+    expect(dut.io.dataOut, i.U)
   }
 }
 
 object EccTester extends App {
   iotesters.Driver.execute(Array("--target-dir", "generated", "--generate-vcd-output", "on"), () => new EccPair(8)) {
-    c => new EccTester(c)
+    dut => new EccTester(dut)
   }
 }


### PR DESCRIPTION
New module which supports a Hamming-code Error Correction generator and checker.  The modules support single-bit error correction and optional double-bit error detection.  