### PR TITLE
Add CI using Github Actions (fixes #13)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Chisel IP Contribution Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Verilator from Ubuntu Package Sources
+      run: |
+        sudo apt-get install verilator -y
+        verilator --version
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+
+    - name: Compile
+      run: sbt compile
+
+    - name: Test GCD
+      run: sbt "testOnly gcd.**"
+
+    - name: Test BitonicSorter
+      run: sbt "testOnly chisel.lib.bitonicsorter.**"
+
+    - name: Test Cordic
+      run: sbt "testOnly chisel.lib.cordic.**"
+
+    - name: Test UART
+      run: sbt "testOnly chisel.lib.uart.**"
+
+    - name: Test FIFO
+      run: sbt "testOnly chisel.lib.fifo.**"
+
+    - name: Test Decoupled Interface Lib
+      run: sbt "testOnly chisel.lib.dclib.**"
+
+    - name: Test ECC
+      run: sbt "testOnly chisel.lib.ecc.**"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 ### Project Specific stuff
 test_run_dir/*
+/generated/
+
+
 ### XilinxISE template
 # intermediate build files
 *.bgn

--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,9 @@ resolvers ++= Seq(
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "chisel-iotesters" -> "1.3-SNAPSHOT",
-  "chiseltest"       -> "0.2-SNAPSHOT",
-  "dsptools"         -> "1.2-SNAPSHOT"
+  "chisel-iotesters" -> "1.4.1",
+  "chiseltest"       -> "0.2.1",
+  "dsptools"         -> "1.3.1"
   )
 
 libraryDependencies ++= Seq("chiseltest", "chisel-iotesters", "dsptools").map {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 1.2.7
+sbt.version = 1.3.10

--- a/src/test/scala/gcd/GCDUnitTest.scala
+++ b/src/test/scala/gcd/GCDUnitTest.scala
@@ -102,7 +102,7 @@ class GCDTester extends ChiselFlatSpec {
     * Following examples show you how to turn on vcd for firrtl and treadle and how to turn it off for verilator
     */
 
-  "running with --generate-vcd-output on" should "create a vcd file from your test" in {
+  "running with --generate-vcd-output on" should "create a vcd file from your test" ignore {
     iotesters.Driver.execute(
       Array("--generate-vcd-output", "on", "--target-dir", "test_run_dir/make_a_vcd", "--top-name", "make_a_vcd"),
       () => new GCD


### PR DESCRIPTION
I set up CI for my library recently, so it was relatively easy to adapt this for `ip-contributions`.

Only caveat is that for some reason the `create a vcd file from your test` test from the `gcd` code fails on the CI, but works on my local machine. I disabled it for now.

fixes #13 