### PR TITLE
Add DCCredit module and unit tests

### DIFF
--- a/src/main/scala/chisel/lib/dclib/DCCredit.scala
+++ b/src/main/scala/chisel/lib/dclib/DCCredit.scala
@@ -1,0 +1,56 @@
+package chisel.lib.dclib
+
+import chisel3._
+import chisel3.util._
+
+/**
+ * Creates a new signal class for sending credit-based flow control.
+ *
+ * This is useful for building systems which are insensitive to variable latency
+ * delays.
+ */
+class CreditIO[D <: Data](data: D) extends Bundle {
+  val valid = Output(Bool())
+  val credit = Input(Bool())
+  val bits = Output(data.cloneType)
+  override def cloneType =
+    new CreditIO(bits.cloneType).asInstanceOf[this.type]
+}
+
+class DCCreditSender[D <: Data](data: D, maxCredit: Int) extends Module {
+  val io = IO(new Bundle {
+    val enq = Flipped(new DecoupledIO(data.cloneType))
+    val deq = new CreditIO(data.cloneType)
+  })
+  require(maxCredit >= 1)
+
+  val icredit = RegNext(io.deq.credit)
+  val curCredit = RegInit(init=maxCredit.U)
+  when (icredit && !io.enq.fire()) {
+    curCredit := curCredit + 1.U
+  }.elsewhen(!icredit && io.enq.fire()) {
+    curCredit := curCredit - 1.U
+  }
+  io.enq.ready := curCredit > 0.U
+  val dataOut = RegEnable(next=io.enq.bits, enable=io.enq.fire())
+  val validOut = RegNext(next=io.enq.fire(), init=false.B)
+  io.deq.valid := validOut
+  io.deq.bits := dataOut
+}
+
+class DCCreditReceiver[D <: Data](data: D, maxCredit: Int) extends Module {
+  val io = IO(new Bundle {
+    val enq = Flipped(new CreditIO(data.cloneType))
+    val deq = new DecoupledIO(data.cloneType)
+  })
+  require(maxCredit >= 1)
+
+  val ivalid = RegNext(io.enq.valid)
+  val idata = RegNext(io.enq.bits)
+  val outFifo = Module(new Queue(data.cloneType, maxCredit))
+  outFifo.io.enq.valid := ivalid
+  outFifo.io.enq.bits := idata
+  io.deq <> outFifo.io.deq
+  val ocredit = RegNext(next=outFifo.io.deq.fire(), init=false.B)
+  io.enq.credit := ocredit
+}

--- a/src/main/scala/chisel/lib/dclib/DCCrossbar.scala
+++ b/src/main/scala/chisel/lib/dclib/DCCrossbar.scala
@@ -1,0 +1,33 @@
+package chisel.lib.dclib
+
+import chisel3._
+import chisel3.util.{DecoupledIO, log2Ceil}
+
+/**
+ * A simple crossbar to connect M inputs to N outputs.  The crossbar should be
+ * nonblocking in that as long as inputs do not request the same output all
+ * transactions can completed simultaneously.
+ *
+ * Implemented using DCDemux and DCArbiter
+ */
+class DCCrossbar[D <: Data](data: D, inputs: Int, outputs : Int) extends Module {
+  val io = IO(new Bundle {
+    val sel = Input(Vec(inputs, UInt(log2Ceil(outputs).W)))
+    val c = Vec(inputs, Flipped(new DecoupledIO(data.cloneType)))
+    val p = Vec(outputs, new DecoupledIO(data.cloneType))
+  })
+  override def desiredName: String = "DCCrossbar_" + data.toString + "_M" + inputs + "N" + outputs
+  val demuxList = for (i <- 0 until inputs) yield Module(new DCDemux(data, outputs))
+  val arbList = for (i <- 0 until outputs) yield Module(new DCArbiter(data, inputs, false))
+  for (i <- 0 until inputs) {
+    demuxList(i).io.c <> io.c(i)
+    demuxList(i).io.sel := io.sel(i)
+
+    for (j <- 0 until outputs) {
+      demuxList(i).io.p(j) <> arbList(j).io.c(i)
+    }
+  }
+  for (i <- 0 until outputs) {
+    arbList(i).io.p <> io.p(i)
+  }
+}

--- a/src/test/scala/chisel/lib/dclib/CreditTester.scala
+++ b/src/test/scala/chisel/lib/dclib/CreditTester.scala
@@ -1,0 +1,105 @@
+package chisel.lib.dclib
+
+import chisel3._
+import chisel3.util._
+import chiseltest._
+import org.scalatest._
+import chiseltest.experimental.TestOptionBuilder._
+import chiseltest.internal.WriteVcdAnnotation
+
+class CreditHarness(delay : Int, maxCredit : Int) extends Module {
+  val io = IO(new Bundle {
+    val dataIn = Flipped(Decoupled(UInt(8.W)))
+    val dataOut = Decoupled(UInt(8.W))
+    val backpressured = Output(Bool())
+  })
+  val sender = Module(new DCCreditSender(io.dataIn.bits, maxCredit))
+  val receiver = Module(new DCCreditReceiver(io.dataIn.bits, maxCredit))
+  val backpressured = RegInit(false.B)
+
+  if (delay >= 1) {
+    val delayPipe = Wire(Vec(delay, new CreditIO(io.dataIn.bits)))
+    sender.io.deq.credit := RegNext(delayPipe(0).credit)
+    delayPipe(0).valid := RegNext(sender.io.deq.valid)
+    delayPipe(0).bits := RegNext(sender.io.deq.bits)
+    receiver.io.enq.valid := RegNext(delayPipe(delay-1).valid)
+    receiver.io.enq.bits := RegNext(delayPipe(delay-1).bits)
+    delayPipe(delay-1).credit := RegNext(receiver.io.enq.credit)
+
+    if (delay >= 2) {
+      for (i <- 0 to delay - 2) {
+        delayPipe(i).credit := RegNext(delayPipe(i + 1).credit)
+        delayPipe(i + 1).valid := RegNext(delayPipe(i).valid)
+        delayPipe(i + 1).bits := RegNext(delayPipe(i).bits)
+      }
+    }
+  } else {
+    sender.io.deq <> receiver.io.enq
+  }
+
+  when (io.dataIn.valid && !io.dataIn.ready) {
+    backpressured := true.B
+  }
+  io.dataIn <> sender.io.enq
+  DCOutput(receiver.io.deq) <> io.dataOut
+  io.backpressured := backpressured
+}
+
+class CreditTester extends FlatSpec with ChiselScalatestTester with Matchers {
+  behavior of "Testers2 with Queue"
+
+  it should "test fixed credit with variable delay" in {
+    for (n <- 0 to 5) {
+      test(new CreditHarness(n, 4)).withAnnotations(Seq(WriteVcdAnnotation)) {
+        c => {
+          c.io.dataIn.initSource().setSourceClock(c.clock)
+          c.io.dataOut.initSink().setSinkClock(c.clock)
+
+          val dataPattern = for (i <- 1 to 50) yield i.U
+          fork {
+            c.io.dataIn.enqueueSeq(dataPattern)
+          }
+          c.io.dataOut.expectDequeueSeq(dataPattern)
+        }
+      }
+    }
+  }
+
+  it should "not flow control with sufficient credit" in {
+    for (n <- 4 to 10) {
+      test(new CreditHarness(n, n*3+6)).withAnnotations(Seq(WriteVcdAnnotation)) {
+        c => {
+          c.io.dataIn.initSource().setSourceClock(c.clock)
+          c.io.dataOut.initSink().setSinkClock(c.clock)
+
+          val dataPattern = for (i <- 1 to n*5) yield i.U
+          fork {
+            c.io.dataIn.enqueueSeq(dataPattern)
+          }
+          c.io.dataOut.expectDequeueSeq(dataPattern)
+
+          // check that sender never asserted backpressure during test
+          c.io.backpressured.expect(false.B)
+        }
+      }
+    }
+  }
+
+  it should "flow control with small credit" in {
+    for (n <- 2 to 10) {
+      test(new CreditHarness(n, 2)).withAnnotations(Seq(WriteVcdAnnotation)) {
+        c => {
+          c.io.dataIn.initSource().setSourceClock(c.clock)
+          c.io.dataOut.initSink().setSinkClock(c.clock)
+
+          val dataPattern = for (i <- 1 to n*5) yield i.U
+          fork {
+            c.io.dataIn.enqueueSeq(dataPattern)
+          }
+          c.io.dataOut.expectDequeueSeq(dataPattern)
+          c.io.backpressured.expect(true.B)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the DCCredit module to dclib, which converts from a decoupled interface to a credit-based interface and vice-versa.

Adds supporting unit tests using testers2 queue module.