### PR TITLE
Empty condition change

### DIFF
--- a/src/main/scala/chisel/lib/fifo/RegFifo.scala
+++ b/src/main/scala/chisel/lib/fifo/RegFifo.scala
@@ -40,7 +40,7 @@ class RegFifo[T <: Data](gen: T, depth: Int) extends Fifo(gen: T, depth: Int) {
 
   when (io.deq.ready && !emptyReg) {
     fullReg := false.B
-    emptyReg := nextRead === writePtr
+    emptyReg := (nextRead === writePtr) && !io.enq.valid
     incrRead := true.B
   }
 


### PR DESCRIPTION
(nextRead === writePtr) is only empty condition when we don't write at the current location, when we are writing it is legal for read logic to jump to the nextRead pointer on the next cycle.